### PR TITLE
adds two migrations to correct date columns in items and bookings tables

### DIFF
--- a/db/migrate/20240313113412_add_date_available_until_to_item.rb
+++ b/db/migrate/20240313113412_add_date_available_until_to_item.rb
@@ -1,0 +1,6 @@
+class AddDateAvailableUntilToItem < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :items, :date_available, :date_available_from
+    add_column :items, :date_available_until, :date
+  end
+end

--- a/db/migrate/20240313114630_add_date_booked_until_to_bookings.rb
+++ b/db/migrate/20240313114630_add_date_booked_until_to_bookings.rb
@@ -1,0 +1,6 @@
+class AddDateBookedUntilToBookings < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :bookings, :date_booked, :date_booked_start
+    add_column :bookings, :date_booked_end, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_12_153306) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_13_114630) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -43,11 +43,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_12_153306) do
   end
 
   create_table "bookings", force: :cascade do |t|
-    t.date "date_booked"
+    t.date "date_booked_start"
     t.bigint "user_id", null: false
     t.bigint "item_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "date_booked_end"
     t.index ["item_id"], name: "index_bookings_on_item_id"
     t.index ["user_id"], name: "index_bookings_on_user_id"
   end
@@ -57,9 +58,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_12_153306) do
     t.text "description"
     t.float "price"
     t.string "location"
-    t.date "date_available"
+    t.date "date_available_from"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "date_available_until"
   end
 
   create_table "reviews", force: :cascade do |t|


### PR DESCRIPTION
![image](https://github.com/BethGeast/AirDIY/assets/157635298/f76fdf42-eafd-4ec1-aa8b-47e817dab75a)

new schema for db tables