### PR TITLE
removes TODO on homepage and fixes error with remove favorite

### DIFF
--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -9,8 +9,8 @@
             <% @favorites.each do |favorite| %>
               <li class="list-group-item d-flex justify-content-between align-items-center">
                 <%= link_to favorite.item.name, item_path(favorite.item_id), class: "text-decoration-none text-dark" %>
-                <%= link_to favorite_path(favorite), method: :delete, class: "btn btn-link text-danger p-0",
-                            data: { turbo_confirm: "Are you sure you want to remove this item from your favorites list?" } do %>
+                <%= link_to favorite_path(favorite), class: "btn btn-link text-danger p-0",
+                            data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to remove this item from your favorites list?" } do %>
                   <i class="fas fa-times"></i>
                 <% end %>
               </li>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,7 +1,7 @@
 <div class="container mt-5">
   <div class="row mb-3">
     <div class="col-md-12">
-      <p>todo put filters here</p>
+      <p></p>
     </div>
   </div>
 


### PR DESCRIPTION
- TODO text placeholder on homepage for where filters were previously going to be added.
- Trying to remove a favorite from favorite index now works.